### PR TITLE
Add support for php7.1.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "goldinteractive/craft3-sitecopy",
   "description": "",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "MIT",
   "type": "craft-plugin",
   "minimum-stability": "dev",

--- a/src/SiteCopy.php
+++ b/src/SiteCopy.php
@@ -8,7 +8,6 @@ namespace goldinteractive\sitecopy;
 
 use craft\base\Plugin;
 
-use stdClass;
 use Craft;
 use craft\elements\Entry;
 use craft\events\ElementEvent;
@@ -101,8 +100,12 @@ class SiteCopy extends Plugin
      * @param Entry|craft\commerce\elements\Product|stdClass $element
      * @return string|void
      */
-    private function editDetailsHook(stdClass $element)
+    private function editDetailsHook($element)
     {
+        if (!is_object($element)) {
+            throw new \Exception('Given value must be an object!');
+        }
+
         $isNew = $element->id === null;
         $sites = $element->getSupportedSites();
 

--- a/src/SiteCopy.php
+++ b/src/SiteCopy.php
@@ -8,6 +8,7 @@ namespace goldinteractive\sitecopy;
 
 use craft\base\Plugin;
 
+use stdClass;
 use Craft;
 use craft\elements\Entry;
 use craft\events\ElementEvent;
@@ -97,10 +98,10 @@ class SiteCopy extends Plugin
     }
 
     /**
-     * @param Entry|craft\commerce\elements\Product|object $element
+     * @param Entry|craft\commerce\elements\Product|stdClass $element
      * @return string|void
      */
-    private function editDetailsHook(object $element)
+    private function editDetailsHook(stdClass $element)
     {
         $isNew = $element->id === null;
         $sites = $element->getSupportedSites();

--- a/src/services/SiteCopy.php
+++ b/src/services/SiteCopy.php
@@ -6,7 +6,6 @@
 
 namespace goldinteractive\sitecopy\services;
 
-use stdClass;
 use Craft;
 use craft\base\Component;
 use craft\base\Element;
@@ -179,11 +178,16 @@ class SiteCopy extends Component
     }
 
     /**
-     * @param Entry|craft\commerce\elements\Product|stdClass $element
+     * @param Entry|craft\commerce\elements\Product $element
      * @return array
+     * @throws \Exception
      */
-    public function handleSiteCopyActiveState(stdClass $element)
+    public function handleSiteCopyActiveState($element)
     {
+        if (!is_object($element)) {
+            throw new \Exception('Given value must be an object!');
+        }
+
         $siteCopyEnabled = false;
         $selectedSites = [];
 

--- a/src/services/SiteCopy.php
+++ b/src/services/SiteCopy.php
@@ -6,6 +6,7 @@
 
 namespace goldinteractive\sitecopy\services;
 
+use stdClass;
 use Craft;
 use craft\base\Component;
 use craft\base\Element;
@@ -178,10 +179,10 @@ class SiteCopy extends Component
     }
 
     /**
-     * @param Entry|craft\commerce\elements\Product|object $element
+     * @param Entry|craft\commerce\elements\Product|stdClass $element
      * @return array
      */
-    public function handleSiteCopyActiveState(object $element)
+    public function handleSiteCopyActiveState(stdClass $element)
     {
         $siteCopyEnabled = false;
         $selectedSites = [];


### PR DESCRIPTION
I had a problem with this error. It was caused by using the type hint `object`. This was introduced in php 7.2. As our environment still runs with php 7.1, I got this error.

Since Craft CMS itself needs php >=7.0.0, I think it's the right way is to use `is_object` instead of `object` since `\stdClass` isn't the same as `object`.
https://github.com/craftcms/cms/blob/develop/composer.json#L21

```
Argument 1 passed to goldinteractive\sitecopy\SiteCopy::editDetailsHook() must be an instance of goldinteractive\sitecopy\object, instance of craft\elements\Entry given
```

I also want to thank you for your plugin. It saved us a lot of time and hassle. 