### PR TITLE
Add support for php7.1

### DIFF
--- a/src/SiteCopy.php
+++ b/src/SiteCopy.php
@@ -99,9 +99,14 @@ class SiteCopy extends Plugin
     /**
      * @param Entry|craft\commerce\elements\Product|object $element
      * @return string|void
+     * @throws \Exception
      */
-    private function editDetailsHook(object $element)
+    private function editDetailsHook($element)
     {
+        if (!is_object($element)) {
+            throw new \Exception('Given value must be an object!');
+        }
+
         $isNew = $element->id === null;
         $sites = $element->getSupportedSites();
 

--- a/src/services/SiteCopy.php
+++ b/src/services/SiteCopy.php
@@ -178,11 +178,16 @@ class SiteCopy extends Component
     }
 
     /**
-     * @param Entry|craft\commerce\elements\Product|object $element
+     * @param Entry|craft\commerce\elements\Product $element
      * @return array
+     * @throws \Exception
      */
-    public function handleSiteCopyActiveState(object $element)
+    public function handleSiteCopyActiveState($element)
     {
+        if (!is_object($element)) {
+            throw new \Exception('Given value must be an object!');
+        }
+
         $siteCopyEnabled = false;
         $selectedSites = [];
 


### PR DESCRIPTION
I had a problem with this error. It was caused by using the type hint `object`. This was introduced in php 7.2. As our environment still runs with php 7.1, I got this error.

Since Craft CMS itself needs php >=7.0.0, I think it's the right way is to use `is_object` instead of `object` since `\stdClass` isn't the same as `object`.
https://github.com/craftcms/cms/blob/develop/composer.json#L21

```
Argument 1 passed to goldinteractive\sitecopy\SiteCopy::editDetailsHook() must be an instance of goldinteractive\sitecopy\object, instance of craft\elements\Entry given
```

I also want to thank you for your plugin. It saved us a lot of time and hassle. 