### PR TITLE
Change OR  to keep looking after match

### DIFF
--- a/src/services/SiteCopy.php
+++ b/src/services/SiteCopy.php
@@ -292,9 +292,6 @@ class SiteCopy extends Component
                     $siteCopyEnabled = true;
                     $selectedSites[] = (int)$targetId;
 
-                    if ($settings['method'] == 'or') {
-                        break;
-                    }
                 } elseif ($settings['method'] == 'and' && (int)$targetId !== $element->siteId) {
                     // check failed, revert values to default
                     $siteCopyEnabled = false;


### PR DESCRIPTION
Succested change to fix my issue #14 

I'm not sure if you had a usecase where that break led to the desired result, but this small chance greatly increases the usability for pages with more than 2 langages.