### PR TITLE
Set propagating to true before save

### DIFF
--- a/src/jobs/SyncElementContent.php
+++ b/src/jobs/SyncElementContent.php
@@ -76,6 +76,7 @@ class SyncElementContent extends BaseJob
             }
 
             $siteElement->setScenario(Element::SCENARIO_ESSENTIALS);
+            $siteElement->propagating = true;
             $elementsService->saveElement($siteElement);
 
             $currentSite++;


### PR DESCRIPTION
### Prevent SiteCopy from deleting Matrix content with Propagation Method set to 'all'

While testing your plugin I encountered a weird bug: after adding a new block to a matrix field and saving with the plugin enabled, it _sometimes_ deleted the whole existing matrix content and replaced it with the new block I added to the matrix.

I have spent a lot of time tracking the issue and ultimately found the culprit: the "Propagation Method" in my Matrix Field was set to "Save blocks to all sites the owner element is saved in". The way I understand it this also makes craft try to copy any change to the matrix layout (= if I add / remove a block but not if I change the content of a block) to my different sites and this led to a problem when the plugin tried to save to these sites at the same time -> because of the timing it sometimes worked and sometimes it deleted the old matrix content. I did not want to change the propagation method though because it is useful on the other entries the matrix is used in.

This one line change fixed my issue (at least I did not ecounter it anymore after a lot of testing) and according to the documentation it makes perfect sense to set it before saving the element:

> propagating: 'Whether the element is being saved in the context of propagating another site's version of the element'.

Source: https://docs.craftcms.com/api/v3/craft-base-elementtrait.html#public-properties

The same issue exists when using sitecopy with the SuperTable plugin but this is also resolved with the succested change.